### PR TITLE
feat: split patient extraction into identity and demographics agents

### DIFF
--- a/lib/agents/patient_demographics_agent.py
+++ b/lib/agents/patient_demographics_agent.py
@@ -79,6 +79,7 @@ Each field (except the *_unit fields) is an EvidenceBlock containing:
   - Other: aunt, uncle, cousin, grandparent, or other relative
   - Unknown: relationship not specified
   - Determine relative to the provided Proband Identifier, using text descriptions and pedigree structure.
+  - HARD RULE: if this patient's identifier equals the provided Proband Identifier, relationship_to_proband MUST be Proband (this keeps it consistent with the patient's proband status determined upstream).
 
 - twin_type (EvidenceBlock[enum: Monozygotic, Dizygotic, Unknown] or null):
   - Monozygotic: identical twins (count as 1 segregation)

--- a/lib/agents/patient_demographics_agent.py
+++ b/lib/agents/patient_demographics_agent.py
@@ -1,0 +1,107 @@
+from agents import Agent
+
+from lib.agents.base_instructions import BASE_SYSTEM_INSTRUCTIONS
+from lib.agents.core_extraction_rules import CORE_EXTRACTION_SPEC
+from lib.core.environment import env
+from lib.models.patient import PatientDemographics
+
+PATIENT_DEMOGRAPHICS_INSTRUCTIONS = """
+System: You are an expert clinical data curator.
+
+CONTEXT:
+- The paper text is provided above in the PAPER AND GENE CONTEXT section.
+- A single, already-identified patient is provided below as "Patient JSON"
+  (identifier + proband status). Extract demographics for THAT patient only.
+- The proband identifier for this patient's family is provided below as
+  "Proband Identifier" so relationship_to_proband can be determined.
+- A structured description of a pedigree (if present) will be provided below.
+
+Task: Extract demographic and clinical attributes for the single provided patient.
+Do NOT extract other patients, re-derive the patient's identifier, or reassign
+families or proband status — those are fixed by upstream extraction.
+
+Fields to extract:
+
+Each field (except the *_unit fields) is an EvidenceBlock containing:
+  - value: the extracted data
+  - reasoning: explanation of how the value was determined
+  - quote: verbatim quote from text (when available)
+  - table_id: if derived from a table
+  - image_id: if derived from a figure/pedigree
+  At least one of quote, table_id, or image_id is required (unless the value is
+  Unknown/None).
+
+- sex (EvidenceBlock[enum: Male, Female, Intersex, MTF/Transwoman/Transgender Female, FTM/Transman/Transgender Male, Ambiguous/Unable to Determine, Other, Unknown]):
+  - Extract sex/gender as explicitly stated in text or pedigree
+
+- age_diagnosis, age_report, age_death (EvidenceBlock[int | None]):
+  - Extract ages as reported in text, tables, or pedigrees
+  - Report the numeric value as an integer
+  - None if not stated
+
+- age_diagnosis_unit, age_report_unit, age_death_unit (enum: Years, Months, Days):
+  - Extract the unit of measurement for the corresponding age field
+  - Match the unit as stated in the source text
+  - Must be populated if the corresponding age field is populated; must be null if age is null
+  - Prefer the unit as explicitly stated; if ambiguous or missing, infer from context (e.g., decimal ages typically indicate years)
+  - If the unit is hours, round to the nearest day for the age value and set unit to Days
+  - Note that these are not EvidenceBlocks, we only expect the raw enum!
+
+- country_of_origin (EvidenceBlock[enum of valid country names]):
+  - Extract from explicit geographic references
+
+- race (EvidenceBlock[enum: American Indian or Alaska Native, Asian, Black, Native Hawaiian or Other Pacific Islander, White, Mixed, Unknown]):
+  - Normalize specific subgroups to the closest enum value when applicable.
+  - Extract from demographic tables or textual descriptions
+
+- ethnicity (EvidenceBlock[enum: Hispanic or Latino, Not Hispanic or Latino, Unknown]):
+  - Extract from demographic tables or textual descriptions
+  - This is independent of race; a patient can be any race and Hispanic or Latino, or not
+
+- affected_status (EvidenceBlock[enum: Affected, Unaffected, Unknown]):
+  - Affected: explicitly reported condition
+  - Unaffected: explicitly reported as not affected
+  - Unknown: not stated or unclear
+
+- is_obligate_carrier (EvidenceBlock[bool]):
+  - True: individual is inferred to carry the variant by virtue of their pedigree position alone
+    (e.g., parent of affected child, sibling of affected individual with affected parent).
+    Do NOT mark as True if genotyping confirms the variant; only for pedigree-inferred carriers.
+  - False: not an obligate carrier (either directly genotyped, affected, or not in obligate position).
+  - Use pedigree description and explicit carrier statements in text as evidence.
+
+- relationship_to_proband (EvidenceBlock[enum: Proband, Parent, Sibling, Half-Sibling, Child, Other, Unknown]):
+  - Proband: this patient IS the proband (i.e., this patient's identifier equals the provided Proband Identifier)
+  - Parent: father or mother of the proband
+  - Sibling: brother or sister of the proband (full sibling)
+  - Half-Sibling: shares one parent with the proband
+  - Child: son or daughter of the proband
+  - Other: aunt, uncle, cousin, grandparent, or other relative
+  - Unknown: relationship not specified
+  - Determine relative to the provided Proband Identifier, using text descriptions and pedigree structure.
+
+- twin_type (EvidenceBlock[enum: Monozygotic, Dizygotic, Unknown] or null):
+  - Monozygotic: identical twins (count as 1 segregation)
+  - Dizygotic: fraternal/non-identical twins (count as 2 segregations)
+  - Unknown: twin status stated but type not specified
+  - null: patient is not a twin
+  - Extract only when explicitly mentioned; if not a twin, return null.
+
+Guidelines:
+
+1. Extract only explicitly stated information. Do NOT infer.
+2. Use enum values when possible; otherwise use "Other" or "Unknown".
+3. If a field is not stated for this patient, return Unknown (or None for ages/twin_type).
+"""
+
+PATIENT_DEMOGRAPHICS_AGENT_INSTRUCTIONS = (
+    PATIENT_DEMOGRAPHICS_INSTRUCTIONS + '\n\n' + CORE_EXTRACTION_SPEC
+)
+
+
+agent = Agent(
+    name='patient_demographics_extractor',
+    instructions=BASE_SYSTEM_INSTRUCTIONS,
+    model=env.OPENAI_API_DEPLOYMENT,
+    output_type=PatientDemographics,
+)

--- a/lib/agents/patient_extraction_agent.py
+++ b/lib/agents/patient_extraction_agent.py
@@ -57,6 +57,14 @@ Each field is an EvidenceBlock containing:
   - Unknown: unclear
   - Proband identification is a comparison across all patients in a family, so decide it here where the whole cohort is visible (not per-patient downstream).
 
+- family_identifier (EvidenceBlock[string]):
+  - The identifier of the biological family this patient belongs to. Its value MUST
+    exactly match the identifier of one of the families in the "families" list below.
+  - Every patient must carry a family_identifier; it is how each patient is linked to
+    its family (see FAMILY GROUPING for how to derive and label families).
+  - reasoning should explain the linkage (e.g., "listed under Family 2 in Table 1",
+    "described as the proband's sibling").
+
 Guidelines:
 
 1. Extract only explicitly stated information. Do NOT infer.

--- a/lib/agents/patient_extraction_agent.py
+++ b/lib/agents/patient_extraction_agent.py
@@ -3,7 +3,7 @@ from agents import Agent
 from lib.agents.base_instructions import BASE_SYSTEM_INSTRUCTIONS
 from lib.agents.core_extraction_rules import CORE_EXTRACTION_SPEC
 from lib.core.environment import env
-from lib.models.patient import Patient, PatientExtractionOutput
+from lib.models.patient import PatientExtractionOutput
 
 PATIENT_EXTRACTION_INSTRUCTIONS = f"""
 System: You are an expert clinical data curator.
@@ -12,7 +12,9 @@ CONTEXT:
 - The paper text is provided above in the PAPER AND GENE CONTEXT section.
 - A structured description of a pedigree (if present) will be provided below.
 
-Task: Extract patient-level demographic information for each individual human patient explicitly described in the text, distinguishing clearly between probands and non-probands. ALSO group extracted patients into biological families.
+Task: Identify each individual human patient explicitly described in the text and assign each a stable identifier, distinguishing clearly between probands and non-probands. ALSO group extracted patients into biological families.
+
+Note: This agent extracts ONLY patient identity (identifier + proband status) and family structure. Per-patient demographic and clinical details (sex, ages, country of origin, race, ethnicity, affected status, carrier status, relationship to proband, twin type) are extracted separately by a downstream patient demographics agent — do NOT extract them here.
 
 Pedigree Input (if present):
 - image_id: integer index of the pedigree image
@@ -53,62 +55,7 @@ Each field is an EvidenceBlock containing:
   - Proband: explicitly described as proband/index case, OR the individual discussed in most detail in the paper when no explicit proband is identified (explain the rationale in the reasoning block)
   - Non-Proband: clearly another cohort member or relative
   - Unknown: unclear
-
-- sex (EvidenceBlock[enum: Male, Female, Intersex, MTF/Transwoman/Transgender Female, FTM/Transman/Transgender Male, Ambiguous/Unable to Determine, Other, Unknown]):
-  - Extract sex/gender as explicitly stated in text or pedigree
-
-- age_diagnosis, age_report, age_death (EvidenceBlock[int | None]):
-  - Extract ages as reported in text, tables, or pedigrees
-  - Report the numeric value as an integer
-  - None if not stated
-
-- age_diagnosis_unit, age_report_unit, age_death_unit (enum: Years, Months, Days):
-  - Extract the unit of measurement for the corresponding age field
-  - Match the unit as stated in the source text
-  - Must be populated if the corresponding age field is populated; must be null if age is null
-  - Prefer the unit as explicitly stated; if ambiguous or missing, infer from context (e.g., decimal ages typically indicate years)
-  - If the unit is hours, round to the nearest day for the age value and set unit to Days
-  - Note that these are not EvidenceBlocks, we only expect the raw enum!
-
-- country_of_origin (EvidenceBlock[enum of valid country names]):
-  - Extract from explicit geographic references
-
-- race (EvidenceBlock[enum: American Indian or Alaska Native, Asian, Black, Native Hawaiian or Other Pacific Islander, White, Mixed, Unknown]):
-  - Normalize specific subgroups to the closest enum value when applicable.
-  - Extract from demographic tables or textual descriptions
-
-- ethnicity (EvidenceBlock[enum: Hispanic or Latino, Not Hispanic or Latino, Unknown]):
-  - Extract from demographic tables or textual descriptions
-  - This is independent of race; a patient can be any race and Hispanic or Latino, or not
-
-- affected_status (EvidenceBlock[enum: Affected, Unaffected, Unknown]):
-  - Affected: explicitly reported condition
-  - Unaffected: explicitly reported as not affected
-  - Unknown: not stated or unclear
-
-- is_obligate_carrier (EvidenceBlock[bool]):
-  - True: individual is inferred to carry the variant by virtue of their pedigree position alone
-    (e.g., parent of affected child, sibling of affected individual with affected parent).
-    Do NOT mark as True if genotyping confirms the variant; only for pedigree-inferred carriers.
-  - False: not an obligate carrier (either directly genotyped, affected, or not in obligate position).
-  - Use pedigree description and explicit carrier statements in text as evidence.
-
-- relationship_to_proband (EvidenceBlock[enum: Proband, Parent, Sibling, Half-Sibling, Child, Other, Unknown]):
-  - Proband: this patient IS the proband
-  - Parent: father or mother of the proband
-  - Sibling: brother or sister of the proband (full sibling)
-  - Half-Sibling: shares one parent with the proband
-  - Child: son or daughter of the proband
-  - Other: aunt, uncle, cousin, grandparent, or other relative
-  - Unknown: relationship not specified
-  - Extract from text descriptions and pedigree structure, relative to the proband within this patient's biological family.
-
-- twin_type (EvidenceBlock[enum: Monozygotic, Dizygotic, Unknown] or null):
-  - Monozygotic: identical twins (count as 1 segregation)
-  - Dizygotic: fraternal/non-identical twins (count as 2 segregations)
-  - Unknown: twin status stated but type not specified
-  - null: patient is not a twin
-  - Extract only when explicitly mentioned; if not a twin, return null.
+  - Proband identification is a comparison across all patients in a family, so decide it here where the whole cohort is visible (not per-patient downstream).
 
 Guidelines:
 

--- a/lib/models/converters.py
+++ b/lib/models/converters.py
@@ -2,7 +2,11 @@ from lib.agents.pedigree_describer_agent import PedigreeExtractionOutput
 from lib.models import PatientDB, PedigreeDB, VariantDB
 from lib.models.evidence_block import HumanEvidenceBlock, ReasoningBlock
 from lib.models.family import Family, FamilyDB
-from lib.models.patient import Patient
+from lib.models.patient import (
+    PatientDemographics,
+    PatientIdentity,
+    placeholder_demographics,
+)
 from lib.models.patient_variant_occurrences import (
     PatientVariantOccurrence,
     PatientVariantOccurrenceDB,
@@ -39,35 +43,56 @@ def family_to_db(paper_id: int, agent_run_id: int, family: Family) -> FamilyDB:
     )
 
 
-def patient_to_db(paper_id: int, patient: Patient, agent_run_id: int) -> PatientDB:
-    """Convert a Patient to PatientDB, splitting values from evidence."""
-    kwargs = {
-        'paper_id': paper_id,
-        'agent_run_id': agent_run_id,
-        'age_diagnosis_unit': patient.age_diagnosis_unit,
-        'age_report_unit': patient.age_report_unit,
-        'age_death_unit': patient.age_death_unit,
-    }
+# Demographic fields carried on both PatientDemographics and PatientDB, each with
+# a paired ``{field}_evidence`` JSON column. ``age_*_unit`` fields are plain enums
+# (no evidence block) and are handled separately.
+_DEMOGRAPHIC_EVIDENCE_FIELDS = [
+    'sex',
+    'age_diagnosis',
+    'age_report',
+    'age_death',
+    'country_of_origin',
+    'race',
+    'ethnicity',
+    'affected_status',
+    'is_obligate_carrier',
+    'relationship_to_proband',
+    'twin_type',
+]
 
-    # Extract values and evidence blocks for evidence block fields
-    # Skip family_identifier (it's handled separately in handlers.py)
-    evidence_fields = [
-        name
-        for name in Patient.model_fields
-        if name
-        not in {
-            'age_diagnosis_unit',
-            'age_report_unit',
-            'age_death_unit',
-            'family_identifier',
-        }
-    ]
-    for field_name in evidence_fields:
-        field_value = getattr(patient, field_name)
-        kwargs[field_name] = field_value.value
-        kwargs[f'{field_name}_evidence'] = field_value.model_dump()
 
-    return PatientDB(**kwargs)
+def patient_identity_to_db(
+    paper_id: int, identity: PatientIdentity, agent_run_id: int
+) -> PatientDB:
+    """Convert a PatientIdentity to PatientDB with placeholder demographics.
+
+    Demographics are filled in later by ``apply_patient_demographics`` once the
+    patient demographics agent runs. ``family_id``/``family_assignment_evidence``
+    are assigned by the caller in handlers.py.
+    """
+    patient_db = PatientDB(
+        paper_id=paper_id,
+        agent_run_id=agent_run_id,
+        identifier=identity.identifier.value,
+        identifier_evidence=identity.identifier.model_dump(),
+        proband_status=identity.proband_status.value,
+        proband_status_evidence=identity.proband_status.model_dump(),
+    )
+    apply_patient_demographics(patient_db, placeholder_demographics())
+    return patient_db
+
+
+def apply_patient_demographics(
+    patient_db: PatientDB, demographics: PatientDemographics
+) -> None:
+    """Overwrite an existing PatientDB row's demographic fields in place."""
+    patient_db.age_diagnosis_unit = demographics.age_diagnosis_unit
+    patient_db.age_report_unit = demographics.age_report_unit
+    patient_db.age_death_unit = demographics.age_death_unit
+    for field_name in _DEMOGRAPHIC_EVIDENCE_FIELDS:
+        block = getattr(demographics, field_name)
+        setattr(patient_db, field_name, block.value)
+        setattr(patient_db, f'{field_name}_evidence', block.model_dump())
 
 
 def pedigree_to_db(paper_id: int, pedigree: PedigreeExtractionOutput) -> PedigreeDB:

--- a/lib/models/patient.py
+++ b/lib/models/patient.py
@@ -354,10 +354,29 @@ class CountryCode(str, Enum):
     Unknown = 'Unknown'
 
 
-class Patient(BaseModel):
+class PatientIdentity(BaseModel):
+    """Identity and cross-patient attributes produced by patient extraction.
+
+    These fields require whole-paper / whole-family context to determine
+    (proband identification is a comparison across all patients in a family,
+    and family assignment relates patients to one another), so they stay in the
+    first-pass extraction agent. Per-patient demographics are attached later by
+    the patient demographics agent (see ``PatientDemographics``).
+    """
+
     identifier: EvidenceBlock[str]
     family_identifier: EvidenceBlock[str]
     proband_status: EvidenceBlock[ProbandStatus]
+
+
+class PatientDemographics(BaseModel):
+    """Per-patient demographic/clinical attributes.
+
+    Attached to an already-identified patient by the patient demographics agent.
+    Each field is knowable from that single patient's own description, so these
+    can be extracted one patient at a time in parallel.
+    """
+
     sex: EvidenceBlock[SexAtBirth]
     age_diagnosis: EvidenceBlock[int | None]
     age_diagnosis_unit: AgeUnit | None = None
@@ -386,7 +405,7 @@ class Patient(BaseModel):
     )
 
     @model_validator(mode='after')
-    def validate_age_units(self) -> 'Patient':
+    def validate_age_units(self) -> 'PatientDemographics':
         """Ensure age fields and their units are both populated or both null."""
         age_pairs = [
             ('age_diagnosis', 'age_diagnosis_unit'),
@@ -403,6 +422,28 @@ class Patient(BaseModel):
         return self
 
 
+def placeholder_demographics() -> 'PatientDemographics':
+    """All-Unknown demographics for a patient whose demographics agent hasn't run.
+
+    Patient extraction inserts the patient row before demographics are known;
+    this fills the required fields with Unknown/None values (which the
+    EvidenceBlock validator allows without an evidence source) until the patient
+    demographics agent overwrites them. ``is_obligate_carrier``,
+    ``relationship_to_proband`` and ``twin_type`` fall back to their field defaults.
+    """
+    reason = 'Not yet extracted'
+    return PatientDemographics(
+        sex=EvidenceBlock(value=SexAtBirth.Unknown, reasoning=reason),
+        age_diagnosis=EvidenceBlock(value=None, reasoning=reason),
+        age_report=EvidenceBlock(value=None, reasoning=reason),
+        age_death=EvidenceBlock(value=None, reasoning=reason),
+        country_of_origin=EvidenceBlock(value=CountryCode.Unknown, reasoning=reason),
+        race=EvidenceBlock(value=Race.Unknown, reasoning=reason),
+        ethnicity=EvidenceBlock(value=Ethnicity.Unknown, reasoning=reason),
+        affected_status=EvidenceBlock(value=AffectedStatus.Unknown, reasoning=reason),
+    )
+
+
 class FamilyEntry(BaseModel):
     """Family grouping with references to patients by their identifier."""
 
@@ -411,7 +452,7 @@ class FamilyEntry(BaseModel):
 
 
 class PatientExtractionOutput(BaseModel):
-    patients: List[Patient]
+    patients: List[PatientIdentity]
     families: List[FamilyEntry]
 
     @model_validator(mode='after')

--- a/lib/tasks/handlers.py
+++ b/lib/tasks/handlers.py
@@ -39,6 +39,12 @@ from lib.agents.paper_section_classifier_agent import (
 from lib.agents.paper_section_classifier_agent import (
     agent as paper_classifier_agent,
 )
+from lib.agents.patient_demographics_agent import (
+    PATIENT_DEMOGRAPHICS_AGENT_INSTRUCTIONS,
+)
+from lib.agents.patient_demographics_agent import (
+    agent as patient_demographics_agent,
+)
 from lib.agents.patient_extraction_agent import (
     PATIENT_EXTRACTION_AGENT_INSTRUCTIONS,
 )
@@ -122,10 +128,11 @@ from lib.models import (
     Zygosity,
 )
 from lib.models.converters import (
+    apply_patient_demographics,
     family_to_db,
     harmonized_variant_to_db,
     hpo_to_db,
-    patient_to_db,
+    patient_identity_to_db,
     patient_variant_occurrence_to_db,
     pedigree_to_db,
     phenotype_to_db,
@@ -139,6 +146,7 @@ from lib.models.mondo import (
     MondoLinkingTarget,
 )
 from lib.models.paper import FileFormat
+from lib.models.patient import ProbandStatus
 from lib.models.phenotype import HPOTerm
 from lib.models.variant import HarmonizedVariant, Variant
 from lib.reference_data.hpo import build_term_lookup, find_matching_hpo_terms
@@ -555,9 +563,9 @@ async def handle_patient_extraction(task_id: int) -> None:
             session.flush()
             family_entries_by_id[entry.family.identifier.value] = db_family.id
 
-        # Insert patients with family assignments
+        # Insert patients (identity only; demographics filled by a later agent)
         for patient_info in result.final_output.patients:
-            db_patient = patient_to_db(paper_id, patient_info, agent_run_id)
+            db_patient = patient_identity_to_db(paper_id, patient_info, agent_run_id)
             # Use family_identifier from patient to find correct family
             family_id_value = patient_info.family_identifier.value
             if family_id_value in family_entries_by_id:
@@ -566,6 +574,112 @@ async def handle_patient_extraction(task_id: int) -> None:
                     patient_info.family_identifier.model_dump()
                 )
             session.add(db_patient)
+
+
+async def handle_patient_demographics(task_id: int) -> None:
+    """Extract demographics for a single already-identified patient."""
+    paper_id: int
+    patient_id: int | None = None
+    supplement_format: FileFormat | None = None
+    stored_conv_id: str | None = None
+    additional_context: str | None = None
+    patient_data: dict | None = None
+    proband_identifier: str | None = None
+    pedigree_descriptions_output: dict | None = None
+    section_classifications: dict | None = None
+
+    with session_scope() as session:
+        task = session.get(TaskDB, task_id)
+        if not task:
+            return
+
+        paper_id = task.paper_id
+        patient_id = task.patient_id
+        if patient_id is None:
+            raise ValueError(
+                f'Task {task_id}: PATIENT_DEMOGRAPHICS requires patient_id'
+            )
+
+        stored_conv_id = task.conversation_id
+        additional_context = task.additional_context
+
+        paper = session.get(PaperDB, paper_id)
+        supplement_format = paper.supplement_format if paper else None
+        section_classifications = paper.section_classifications if paper else None
+
+        patient_row = session.get(PatientDB, patient_id)
+        if not patient_row:
+            return
+
+        patient_data = {
+            'patient_id': patient_row.id,
+            'identifier': patient_row.identifier,
+            'identifier_quote': patient_row.identifier_evidence['quote'],
+            'proband_status': patient_row.proband_status,
+        }
+
+        # Find the proband identifier within this patient's family so the agent
+        # can determine relationship_to_proband consistently.
+        proband_row = (
+            session.query(PatientDB)
+            .filter(
+                PatientDB.family_id == patient_row.family_id,
+                PatientDB.proband_status == ProbandStatus.Proband.value,
+            )
+            .first()
+        )
+        proband_identifier = proband_row.identifier if proband_row else None
+
+        pedigree_row = (
+            session.query(PedigreeDB).filter(PedigreeDB.paper_id == paper_id).first()
+        )
+        pedigree_descriptions_output = (
+            {
+                'image_id': pedigree_row.image_id,
+                'description': pedigree_row.description,
+            }
+            if pedigree_row
+            else None
+        )
+
+    stored_conv_id = await ensure_conversation_id(stored_conv_id)
+
+    if additional_context is not None:
+        # Follow-up: agent has context from conversation
+        message = build_followup_prompt(additional_context)
+        agent = patient_demographics_agent
+    else:
+        # Initial query: build full message with paper + patient data + instructions
+        paper_markdown = relevant_sections_md(
+            paper_id, supplement_format, section_classifications
+        )
+        paper_context = format_paper_context(paper_markdown)
+        message = (
+            f'{paper_context}\n\n'
+            f'Patient JSON:\n{patient_data}\n\n'
+            f'Proband Identifier:\n{proband_identifier}\n\n'
+            f'Pedigree Description:\n{pedigree_descriptions_output}\n\n'
+            f'{PATIENT_DEMOGRAPHICS_AGENT_INSTRUCTIONS}'
+        )
+        agent = patient_demographics_agent
+
+    result = await Runner.run(
+        agent,
+        message,
+        conversation_id=stored_conv_id,
+    )
+    log_cache_metrics('PATIENT_DEMOGRAPHICS', result)
+
+    with session_scope() as session:
+        task = session.get(TaskDB, task_id)
+        if not task:
+            return
+        task.conversation_id = stored_conv_id
+
+        patient_row = session.get(PatientDB, patient_id)
+        if not patient_row:
+            return
+        apply_patient_demographics(patient_row, result.final_output)
 
 
 async def handle_segregation_evidence_extraction(task_id: int) -> None:
@@ -1592,6 +1706,7 @@ TASK_HANDLERS: dict[TaskType, Callable[[int], Awaitable[None]]] = {
     TaskType.VARIANT_EXTRACTION: handle_variant_extraction,
     TaskType.PEDIGREE_DESCRIPTION: handle_pedigree_description,
     TaskType.PATIENT_EXTRACTION: handle_patient_extraction,
+    TaskType.PATIENT_DEMOGRAPHICS: handle_patient_demographics,
     TaskType.SEGREGATION_EVIDENCE_EXTRACTION: handle_segregation_evidence_extraction,
     TaskType.SEGREGATION_ANALYSIS_COMPUTED: handle_segregation_analysis_computed,
     TaskType.VARIANT_HARMONIZATION: handle_variant_harmonization,

--- a/lib/tasks/misc.py
+++ b/lib/tasks/misc.py
@@ -156,6 +156,41 @@ def enqueue_all_instances(
         return [task]
 
 
+def _task_completed(session: Session, paper_id: int, task_type: TaskType) -> bool:
+    """Whether a (global) task of ``task_type`` has completed for this paper."""
+    return (
+        session.query(TaskDB)
+        .filter(
+            TaskDB.paper_id == paper_id,
+            TaskDB.type == task_type,
+            TaskDB.status == TaskStatus.COMPLETED,
+        )
+        .first()
+        is not None
+    )
+
+
+def _patient_demographics_ready(session: Session, paper_id: int) -> bool:
+    """Whether patient identity + all per-patient demographics are complete.
+
+    True once PATIENT_EXTRACTION has completed and every per-patient
+    PATIENT_DEMOGRAPHICS task (if any) has completed. With zero patients there
+    are no demographics tasks, so this reduces to "patient extraction done",
+    preserving the pre-split behavior for papers with no extractable patients.
+    """
+    if not _task_completed(session, paper_id, TaskType.PATIENT_EXTRACTION):
+        return False
+    demographics_tasks = (
+        session.query(TaskDB)
+        .filter(
+            TaskDB.paper_id == paper_id,
+            TaskDB.type == TaskType.PATIENT_DEMOGRAPHICS,
+        )
+        .all()
+    )
+    return all(t.status == TaskStatus.COMPLETED for t in demographics_tasks)
+
+
 def enqueue_successors(session: Session, task: TaskDB) -> None:
     """Create successor tasks when a task completes.
 
@@ -209,7 +244,7 @@ def enqueue_successors(session: Session, task: TaskDB) -> None:
             )
 
         case TaskType.PATIENT_EXTRACTION:
-            # Expand to per-patient PHENOTYPE_EXTRACTION tasks
+            # Expand to per-patient PATIENT_DEMOGRAPHICS tasks
             patients = (
                 session.query(PatientDB)
                 .filter(PatientDB.paper_id == task.paper_id)
@@ -219,22 +254,38 @@ def enqueue_successors(session: Session, task: TaskDB) -> None:
                 enqueue_task(
                     session,
                     paper_id=task.paper_id,
-                    task_type=TaskType.PHENOTYPE_EXTRACTION,
+                    task_type=TaskType.PATIENT_DEMOGRAPHICS,
                     patient_id=patient.id,
                     updated_by_user_id=user_id,
                 )
 
-            # Gate PATIENT_VARIANT_OCCURRENCES on VARIANT_EXTRACTION also being done
-            variant_task = (
-                session.query(TaskDB)
-                .filter(
-                    TaskDB.paper_id == task.paper_id,
-                    TaskDB.type == TaskType.VARIANT_EXTRACTION,
-                    TaskDB.status == TaskStatus.COMPLETED,
+            # With no patients there will be no demographics tasks to drive
+            # PATIENT_VARIANT_OCCURRENCES, so gate it here (on VARIANT_EXTRACTION).
+            if not patients and _task_completed(
+                session, task.paper_id, TaskType.VARIANT_EXTRACTION
+            ):
+                enqueue_task(
+                    session,
+                    paper_id=task.paper_id,
+                    task_type=TaskType.PATIENT_VARIANT_OCCURRENCES,
+                    updated_by_user_id=user_id,
                 )
-                .first()
+
+        case TaskType.PATIENT_DEMOGRAPHICS:
+            # Per-patient PHENOTYPE_EXTRACTION for this patient
+            enqueue_task(
+                session,
+                paper_id=task.paper_id,
+                task_type=TaskType.PHENOTYPE_EXTRACTION,
+                patient_id=task.patient_id,
+                updated_by_user_id=user_id,
             )
-            if variant_task:
+
+            # Fan-in: once all patients have demographics and variants are
+            # extracted, patient-variant occurrences can run.
+            if _patient_demographics_ready(session, task.paper_id) and _task_completed(
+                session, task.paper_id, TaskType.VARIANT_EXTRACTION
+            ):
                 enqueue_task(
                     session,
                     paper_id=task.paper_id,
@@ -258,17 +309,9 @@ def enqueue_successors(session: Session, task: TaskDB) -> None:
                     updated_by_user_id=user_id,
                 )
 
-            # Gate PATIENT_VARIANT_OCCURRENCES on PATIENT_EXTRACTION also being done
-            patient_task = (
-                session.query(TaskDB)
-                .filter(
-                    TaskDB.paper_id == task.paper_id,
-                    TaskDB.type == TaskType.PATIENT_EXTRACTION,
-                    TaskDB.status == TaskStatus.COMPLETED,
-                )
-                .first()
-            )
-            if patient_task:
+            # Gate PATIENT_VARIANT_OCCURRENCES on patient identity + all per-patient
+            # demographics also being done.
+            if _patient_demographics_ready(session, task.paper_id):
                 enqueue_task(
                     session,
                     paper_id=task.paper_id,

--- a/lib/tasks/models.py
+++ b/lib/tasks/models.py
@@ -26,6 +26,7 @@ class TaskType(StrEnum):
     VARIANT_EXTRACTION = 'Variant Extraction'
     PEDIGREE_DESCRIPTION = 'Pedigree Description'
     PATIENT_EXTRACTION = 'Patient Extraction'
+    PATIENT_DEMOGRAPHICS = 'Patient Demographics'  # per-patient
 
     SEGREGATION_EVIDENCE_EXTRACTION = 'Segregation Evidence Extraction'  # per-family
     SEGREGATION_ANALYSIS_COMPUTED = 'Segregation Analysis Computed'  # per-family
@@ -47,7 +48,8 @@ class TaskType(StrEnum):
             TaskType.PAPER_METADATA: 'Extracts paper title, authors, publication date, and other metadata; resolve to PubMed article',
             TaskType.VARIANT_EXTRACTION: 'Identifies genetic variants mentioned in the paper',
             TaskType.PEDIGREE_DESCRIPTION: 'Analyzes the images in the paper to determine if there is a describable pedigree',
-            TaskType.PATIENT_EXTRACTION: 'Extracts patient demographic and clinical information',
+            TaskType.PATIENT_EXTRACTION: 'Identifies patients, assigns identifiers and proband status, and groups them into families',
+            TaskType.PATIENT_DEMOGRAPHICS: 'Attaches demographic and clinical details (sex, ages, race, ethnicity, affected status, etc.) to each identified patient',
             TaskType.SEGREGATION_EVIDENCE_EXTRACTION: 'Collects segregation analysis evidence within each family',
             TaskType.SEGREGATION_ANALYSIS_COMPUTED: 'Computes segregation analysis results per family',
             TaskType.VARIANT_HARMONIZATION: 'Normalizes variants to standard genomic coordinates using ClinVar, dbSNP, ClinGen Allele Registry, and VariantValidator',
@@ -91,7 +93,8 @@ TASK_SUCCESSORS: dict[TaskType, list[TaskType]] = {
         TaskType.PEDIGREE_DESCRIPTION,
     ],
     TaskType.PEDIGREE_DESCRIPTION: [TaskType.PATIENT_EXTRACTION],
-    TaskType.PATIENT_EXTRACTION: [
+    TaskType.PATIENT_EXTRACTION: [TaskType.PATIENT_DEMOGRAPHICS],
+    TaskType.PATIENT_DEMOGRAPHICS: [
         TaskType.PHENOTYPE_EXTRACTION,
         TaskType.PATIENT_VARIANT_OCCURRENCES,
     ],

--- a/test/models/test_converters.py
+++ b/test/models/test_converters.py
@@ -1,12 +1,17 @@
 from lib.models import PaperDB, PaperExtractionOutput, PaperType
-from lib.models.converters import harmonized_variant_to_db, patient_to_db
+from lib.models.converters import (
+    apply_patient_demographics,
+    harmonized_variant_to_db,
+    patient_identity_to_db,
+)
 from lib.models.evidence_block import EvidenceBlock, ReasoningBlock
 from lib.models.patient import (
     AffectedStatus,
     AgeUnit,
     CountryCode,
     Ethnicity,
-    Patient,
+    PatientDemographics,
+    PatientIdentity,
     ProbandStatus,
     Race,
     RelationshipToProband,
@@ -63,32 +68,63 @@ def test_apply_to_handles_none_fields():
     assert paper_db.paper_types == ['Unknown']
 
 
-def test_patient_to_db_maps_all_fields():
-    patient = Patient(
+def _identity(
+    identifier: str = 'P1',
+    family: str = 'Family1',
+    proband: ProbandStatus = ProbandStatus.Proband,
+) -> PatientIdentity:
+    return PatientIdentity(
         identifier=EvidenceBlock(
-            value='P1',
-            quote='referred to as P1',
-            reasoning='labeled P1 in table',
+            value=identifier, quote=f'referred to as {identifier}', reasoning='labeled'
         ),
         family_identifier=EvidenceBlock(
-            value='Family1',
-            quote='Family 1',
-            reasoning='belongs to Family 1',
+            value=family, quote=family, reasoning=f'belongs to {family}'
         ),
         proband_status=EvidenceBlock(
-            value=ProbandStatus.Proband,
-            quote='index case',
-            reasoning='first identified',
+            value=proband, quote='index case', reasoning='stated'
         ),
+    )
+
+
+def test_patient_identity_to_db_sets_identity_and_placeholder_demographics():
+    row = patient_identity_to_db('paper123', _identity(), agent_run_id=1)
+
+    assert row.paper_id == 'paper123'
+    assert row.agent_run_id == 1
+    # Identity fields come from the agent
+    assert row.identifier == 'P1'
+    assert row.proband_status == 'Proband'
+    assert row.identifier_evidence['value'] == 'P1'
+    assert row.identifier_evidence['quote'] == 'referred to as P1'
+    assert row.proband_status_evidence['value'] == 'Proband'
+
+    # Demographics are placeholders until the demographics agent runs
+    assert row.sex == 'Unknown'
+    assert row.country_of_origin == 'Unknown'
+    assert row.race == 'Unknown'
+    assert row.ethnicity == 'Unknown'
+    assert row.affected_status == 'Unknown'
+    assert row.age_diagnosis is None
+    assert row.age_diagnosis_unit is None
+    assert row.age_report is None
+    assert row.age_death is None
+    assert row.is_obligate_carrier is False
+    assert row.relationship_to_proband == 'Unknown'
+    assert row.twin_type is None
+    # Placeholder evidence blocks are populated (NOT NULL columns)
+    assert row.sex_evidence['reasoning'] == 'Not yet extracted'
+    assert row.race_evidence['value'] == 'Unknown'
+
+
+def test_apply_patient_demographics_overwrites_placeholders():
+    row = patient_identity_to_db('paper123', _identity(), agent_run_id=1)
+
+    demographics = PatientDemographics(
         sex=EvidenceBlock(
-            value=SexAtBirth.Female,
-            quote='female patient',
-            reasoning='stated female',
+            value=SexAtBirth.Female, quote='female patient', reasoning='stated female'
         ),
         age_diagnosis=EvidenceBlock(
-            value=5,
-            quote='diagnosed at 5',
-            reasoning='age at diagnosis noted',
+            value=5, quote='diagnosed at 5', reasoning='age at diagnosis noted'
         ),
         age_diagnosis_unit=AgeUnit.Years,
         age_report=EvidenceBlock(
@@ -96,20 +132,13 @@ def test_patient_to_db_maps_all_fields():
         ),
         age_report_unit=AgeUnit.Years,
         age_death=EvidenceBlock(
-            value=None,
-            quote=None,
-            image_id=1,
-            reasoning='no death information available',
+            value=None, image_id=1, reasoning='no death information available'
         ),
         country_of_origin=EvidenceBlock(
-            value=CountryCode.Japan,
-            quote='from Japan',
-            reasoning='origin stated',
+            value=CountryCode.Japan, quote='from Japan', reasoning='origin stated'
         ),
         race=EvidenceBlock(
-            value=Race.Asian,
-            quote='East Asian descent',
-            reasoning='race stated',
+            value=Race.Asian, quote='East Asian descent', reasoning='race stated'
         ),
         ethnicity=EvidenceBlock(
             value=Ethnicity.Not_Hispanic_or_Latino,
@@ -122,12 +151,12 @@ def test_patient_to_db_maps_all_fields():
             reasoning='clearly affected',
         ),
     )
-    row = patient_to_db('paper123', patient, agent_run_id=1)
+    apply_patient_demographics(row, demographics)
 
-    assert row.paper_id == 'paper123'
-    # Values
+    # Identity is untouched
     assert row.identifier == 'P1'
     assert row.proband_status == 'Proband'
+    # Demographics now reflect the agent output
     assert row.sex == 'Female'
     assert row.age_diagnosis == 5
     assert row.age_diagnosis_unit == 'Years'
@@ -139,119 +168,24 @@ def test_patient_to_db_maps_all_fields():
     assert row.race == 'Asian'
     assert row.ethnicity == 'Not Hispanic or Latino'
     assert row.affected_status == 'Affected'
-    # Segregation analysis fields (defaults)
-    assert row.is_obligate_carrier is False
-    assert row.relationship_to_proband == 'Unknown'
-    assert row.twin_type is None
-    # Evidence blocks
-    assert row.identifier_evidence['value'] == 'P1'
-    assert row.identifier_evidence['quote'] == 'referred to as P1'
-    assert row.identifier_evidence['reasoning'] == 'labeled P1 in table'
-    # Segregation evidence blocks (defaults)
-    assert row.is_obligate_carrier_evidence is not None
-    assert row.relationship_to_proband_evidence is not None
-    assert row.twin_type_evidence is not None
+    assert row.sex_evidence['value'] == 'Female'
+    assert row.race_evidence['quote'] == 'East Asian descent'
 
 
-def test_patient_to_db_handles_optional_none_values():
-    patient = Patient(
-        identifier=EvidenceBlock(
-            value='II-2',
-            quote='pedigree notation',
-            reasoning='labeled in pedigree',
-        ),
-        family_identifier=EvidenceBlock(
-            value='Family2',
-            quote='Family 2',
-            reasoning='belongs to Family 2',
-        ),
-        proband_status=EvidenceBlock(
-            value=ProbandStatus.Unknown,
-            quote=None,
-            image_id=1,
-            reasoning='unclear from pedigree',
-        ),
-        sex=EvidenceBlock(
-            value=SexAtBirth.Unknown, table_id=2, reasoning='not specified'
-        ),
-        age_diagnosis=EvidenceBlock(
-            value=None, table_id=2, reasoning='no diagnosis age provided'
-        ),
-        age_report=EvidenceBlock(
-            value=None,
-            quote=None,
-            table_id=2,
-            reasoning='no report age available',
-        ),
-        age_death=EvidenceBlock(
-            value=None, table_id=2, reasoning='no death information'
-        ),
-        country_of_origin=EvidenceBlock(
-            value=CountryCode.Unknown,
-            quote='location not stated',
-            reasoning='no origin information',
-        ),
-        race=EvidenceBlock(
-            value=Race.Unknown,
-            quote=None,
-            image_id=1,
-            reasoning='race not mentioned',
-        ),
-        ethnicity=EvidenceBlock(
-            value=Ethnicity.Unknown,
-            quote=None,
-            image_id=1,
-            reasoning='ethnicity not mentioned',
-        ),
-        affected_status=EvidenceBlock(
-            value=AffectedStatus.Unknown,
-            quote='status unclear',
-            reasoning='phenotype not detailed',
-        ),
-    )
-    row = patient_to_db('paper456', patient, agent_run_id=1)
+def test_apply_patient_demographics_maps_segregation_analysis_fields():
+    """Segregation analysis fields carried on demographics are applied."""
+    row = patient_identity_to_db('paper_seg', _identity(), agent_run_id=1)
 
-    assert row.identifier == 'II-2'
-    assert row.proband_status == 'Unknown'
-    assert row.sex == 'Unknown'
-    assert row.country_of_origin == 'Unknown'
-    assert row.race == 'Unknown'
-    assert row.ethnicity == 'Unknown'
-    assert row.affected_status == 'Unknown'
-    assert row.age_diagnosis is None
-    assert row.age_report is None
-    assert row.age_death is None
-    # Evidence always present
-    assert row.identifier_evidence is not None
-    assert row.proband_status_evidence is not None
-    # Segregation analysis fields (defaults)
-    assert row.is_obligate_carrier is False
-    assert row.relationship_to_proband == 'Unknown'
-    assert row.twin_type is None
-
-
-def test_patient_to_db_maps_segregation_analysis_fields():
-    """Test that segregation analysis fields are correctly converted."""
-    patient = Patient(
-        identifier=EvidenceBlock(value='P1', quote='patient 1', reasoning='labeled P1'),
-        family_identifier=EvidenceBlock(
-            value='FamilyA', quote='Family A', reasoning='belongs to Family A'
-        ),
-        proband_status=EvidenceBlock(
-            value=ProbandStatus.Proband, quote='index', reasoning='proband'
-        ),
+    demographics = PatientDemographics(
         sex=EvidenceBlock(value=SexAtBirth.Male, quote='male', reasoning='stated'),
-        age_diagnosis=EvidenceBlock(value=10, quote='age 10', reasoning='at diagnosis'),
-        age_diagnosis_unit=AgeUnit.Years,
+        age_diagnosis=EvidenceBlock(value=None, table_id=1, reasoning='no age'),
         age_report=EvidenceBlock(value=None, table_id=1, reasoning='no age'),
         age_death=EvidenceBlock(value=None, table_id=1, reasoning='no death info'),
         country_of_origin=EvidenceBlock(
-            value=CountryCode.Unknown, quote='unknown', reasoning='not stated'
+            value=CountryCode.Unknown, reasoning='not stated'
         ),
-        race=EvidenceBlock(value=Race.Unknown, quote='unknown', reasoning='not stated'),
-        ethnicity=EvidenceBlock(
-            value=Ethnicity.Unknown, quote='unknown', reasoning='not stated'
-        ),
+        race=EvidenceBlock(value=Race.Unknown, reasoning='not stated'),
+        ethnicity=EvidenceBlock(value=Ethnicity.Unknown, reasoning='not stated'),
         affected_status=EvidenceBlock(
             value=AffectedStatus.Affected, quote='affected', reasoning='disease'
         ),
@@ -271,14 +205,11 @@ def test_patient_to_db_maps_segregation_analysis_fields():
             reasoning='explicitly stated',
         ),
     )
-    row = patient_to_db('paper_seg', patient, agent_run_id=1)
+    apply_patient_demographics(row, demographics)
 
-    # Segregation fields should be set correctly
     assert row.is_obligate_carrier is True
     assert row.relationship_to_proband == 'Parent'
     assert row.twin_type == 'Monozygotic'
-
-    # Evidence blocks should be serialized
     assert row.is_obligate_carrier_evidence['value'] is True
     assert row.is_obligate_carrier_evidence['quote'] == 'mother of affected child'
     assert row.relationship_to_proband_evidence['value'] == 'Parent'


### PR DESCRIPTION
Patient extraction now produces only patient identity (identifier, proband status) and family grouping in one whole-paper call; a new per-patient demographics agent attaches sex, ages, country, race, ethnicity, affected status, carrier status, relationship-to-proband and twin type.

Proband status and family grouping stay in the first agent because they are cross-patient/whole-family judgments; the demographics agent runs per patient in parallel with the family's proband identifier injected so relationship_to_proband stays consistent.

Wiring: new PATIENT_DEMOGRAPHICS task type fans out from PATIENT_EXTRACTION per patient, then drives PHENOTYPE_EXTRACTION and (once all demographics are done) PATIENT_VARIANT_OCCURRENCES, so downstream segregation sees a populated affected_status. patient_to_db is split into patient_identity_to_db (identity + Unknown placeholders) and apply_patient_demographics (overwrites in place); no schema change required.