### PR TITLE
Move ansible deploy vars into group_vars/all.yml

### DIFF
--- a/infrastructure/ansible/group_vars/all.yml
+++ b/infrastructure/ansible/group_vars/all.yml
@@ -1,0 +1,21 @@
+# Deployment-target values for the CAA VM playbook.
+#
+# These are prod-stable, non-secret values that used to be passed by hand on every
+# run via `-e domain=... -e letsencrypt_email=...`. They are auto-loaded by Ansible
+# for all hosts (group_vars/all is read relative to the playbook), so the cutover /
+# renewal commands no longer need the overrides. Real secrets stay in GCP Secret
+# Manager; only public config lives here.
+#
+# Any value here is still overridable per-run with `-e` (e.g. a staging domain) or
+# with host_vars if a second host is ever added.
+
+# Domain for nginx server_name and the certbot lineage.
+domain: gene-curation-ai.app
+
+# Email for ACME account registration and revocation/infra (expiry) notices.
+letsencrypt_email: clingen-caa@broadinstitute.org
+
+# DNS-01 propagation wait. Must be >= Porkbun's minimum record TTL of 600s, or the
+# plugin warns and challenges may fail; 900 gives margin. Fixed sleep, so it only
+# costs wall-clock time (and is inherited by renewals via the renewal .conf).
+letsencrypt_propagation_seconds: 900

--- a/infrastructure/ansible/playbook.yml
+++ b/infrastructure/ansible/playbook.yml
@@ -3,10 +3,8 @@
 # Ansible Installation:
 #   - `brew install ansible` on Mac.
 #
-# Usage:
-#   ansible-playbook -i <ssh-host>, playbook.yml
-# Example:
-#   ansible-playbook -i dev-caa.us-east4-a.clingen-caa, infrastructure/ansible/playbook.yml
+# Usage (run from the repo root; <ssh-host> is your ~/.ssh/config Host for the VM):
+#   ansible-playbook -i <ssh-host>, infrastructure/ansible/playbook.yml
 #
 # Deployment-target values (domain, letsencrypt_email, letsencrypt_propagation_seconds)
 # are defined in group_vars/all.yml and auto-loaded — no -e needed for a normal prod run.
@@ -29,22 +27,22 @@
 #   git_repo              - Git repository URL (default: https://github.com/clingen-data-model/cur-ai-ss.git)
 #   git_version           - Git ref to deploy (default: main)
 #
-# Examples:
-#   ansible-playbook -i dev-caa, playbook.yml
+# Examples (run from the repo root):
+#   ansible-playbook -i <ssh-host>, infrastructure/ansible/playbook.yml
 #
 #   # Deploy a specific tag
-#   ansible-playbook -i dev-caa, playbook.yml \
+#   ansible-playbook -i <ssh-host>, infrastructure/ansible/playbook.yml \
 #     -e git_version=v1.0.0
 #
 #   # Dry run (check mode)
-#   ansible-playbook -i dev-caa, playbook.yml --check
+#   ansible-playbook -i <ssh-host>, infrastructure/ansible/playbook.yml --check
 #
 #   # Cert-only run (issue/renew TLS + repoint nginx WITHOUT updating app code or
 #   # restarting api/ui/worker). Skips the git pull, uv sync, env, and systemd tasks.
-#   ansible-playbook -i dev-caa, playbook.yml --tags certbot
+#   ansible-playbook -i <ssh-host>, infrastructure/ansible/playbook.yml --tags certbot
 #
 #   # Override a deployment-target default (e.g. staging domain)
-#   ansible-playbook -i dev-caa, playbook.yml -e domain=staging.example.com
+#   ansible-playbook -i <ssh-host>, infrastructure/ansible/playbook.yml -e domain=staging.example.com
 #
 # Note: The trailing comma after the hostname is required for single-host inventory.
 #       The SSH host should be pre-configured in ~/.ssh/config with appropriate
@@ -109,7 +107,10 @@
         that:
           - letsencrypt_email is defined and (letsencrypt_email | length) > 0
           - domain is defined and (domain | length) > 0
-        fail_msg: "Set -e letsencrypt_email=<addr> and -e domain=<fqdn>."
+        fail_msg: >-
+          letsencrypt_email and domain must be set. They normally default from
+          group_vars/all.yml — if this fires, that file is missing/empty or was
+          overridden; supply them with -e letsencrypt_email=<addr> -e domain=<fqdn>.
 
     # --- Package Installation ---
     - name: Update apt cache

--- a/infrastructure/ansible/playbook.yml
+++ b/infrastructure/ansible/playbook.yml
@@ -4,14 +4,18 @@
 #   - `brew install ansible` on Mac.
 #
 # Usage:
-#   ansible-playbook -i <ssh-host>, playbook.yml \
-#     -e domain=example.com
+#   ansible-playbook -i <ssh-host>, playbook.yml
 # Example:
-#   ansible-playbook -i dev-caa.us-east4-a.clingen-caa, infrastructure/ansible/playbook.yml -e gene-curation-ai.app
+#   ansible-playbook -i dev-caa.us-east4-a.clingen-caa, infrastructure/ansible/playbook.yml
 #
-# Required variables:
+# Deployment-target values (domain, letsencrypt_email, letsencrypt_propagation_seconds)
+# are defined in group_vars/all.yml and auto-loaded — no -e needed for a normal prod run.
+# Override any of them per-run with -e (e.g. a staging domain).
+#
 #   domain           - Domain name for nginx server_name and the certbot lineage
-#   letsencrypt_email - Email for ACME account registration and revocation/infra notices.
+#                      (default: gene-curation-ai.app, from group_vars/all.yml)
+#   letsencrypt_email - Email for ACME account registration and revocation/infra notices
+#                      (default: clingen-caa@broadinstitute.org, from group_vars/all.yml)
 #
 # Optional variables:
 #   gcp_project           - CAA project name (default: clingen-caa)
@@ -21,27 +25,26 @@
 #   auth_secrets_secret   - Secret Manager name for the auth/SMTP JSON secret (default: caa-auth-secrets)
 #   porkbun_api_key_secret    - Secret Manager name for the Porkbun API key (default: caa-certbot-porkbun-api-key)
 #   porkbun_secret_key_secret - Secret Manager name for the Porkbun secret key (default: caa-certbot-porkbun-secret-key)
-#   letsencrypt_propagation_seconds - DNS-01 propagation wait (default: 300)
+#   letsencrypt_propagation_seconds - DNS-01 propagation wait (default: 900, from group_vars/all.yml)
 #   git_repo              - Git repository URL (default: https://github.com/clingen-data-model/cur-ai-ss.git)
 #   git_version           - Git ref to deploy (default: main)
 #
 # Examples:
-#   ansible-playbook -i dev-caa, playbook.yml \
-#     -e domain=myapp.example.com \
+#   ansible-playbook -i dev-caa, playbook.yml
 #
 #   # Deploy a specific tag
 #   ansible-playbook -i dev-caa, playbook.yml \
-#     -e domain=myapp.example.com \
 #     -e git_version=v1.0.0
 #
 #   # Dry run (check mode)
-#   ansible-playbook -i dev-caa, playbook.yml --check \
-#     -e domain=myapp.example.com
+#   ansible-playbook -i dev-caa, playbook.yml --check
 #
 #   # Cert-only run (issue/renew TLS + repoint nginx WITHOUT updating app code or
 #   # restarting api/ui/worker). Skips the git pull, uv sync, env, and systemd tasks.
-#   ansible-playbook -i dev-caa, playbook.yml --tags certbot \
-#     -e domain=gene-curation-ai.app -e letsencrypt_email=<ops-email>
+#   ansible-playbook -i dev-caa, playbook.yml --tags certbot
+#
+#   # Override a deployment-target default (e.g. staging domain)
+#   ansible-playbook -i dev-caa, playbook.yml -e domain=staging.example.com
 #
 # Note: The trailing comma after the hostname is required for single-host inventory.
 #       The SSH host should be pre-configured in ~/.ssh/config with appropriate
@@ -93,10 +96,8 @@
     porkbun_secret_key_secret: caa-certbot-porkbun-secret-key
     # Secret Manager cache of the current certbot lineage (restore on reprovision)
     certbot_archive_secret: caa-certbot-le-archive
-    # DNS-01 propagation wait. Must be >= Porkbun's minimum record TTL of 600s, or the
-    # plugin warns and challenges may fail; 900 gives margin. Fixed sleep, so it only
-    # costs wall-clock time (and is inherited by renewals via the renewal .conf).
-    letsencrypt_propagation_seconds: 900
+    # NOTE: domain, letsencrypt_email, and letsencrypt_propagation_seconds are defined
+    # in group_vars/all.yml (auto-loaded). Override any of them per-run with -e.
 
   tasks:
     # --- Preflight ---


### PR DESCRIPTION
Domain, letsencrypt_email, and letsencrypt_propagation_seconds were passed by hand via -e on every playbook run. Add to group_vars/all.yml so they auto-load defaults for a normal prod run. Update the playbook header comments and examples to match.